### PR TITLE
Generate measures for the short data report

### DIFF
--- a/analysis/dataset_definition.py
+++ b/analysis/dataset_definition.py
@@ -1,14 +1,35 @@
+# This script creates a dataset file version of the measures file
+# for testing purposes
+
+import argparse
+from ehrql import codelist_from_csv
+from ehrql.tables.core import clinical_events as events
+from ehrql.tables.core import patients
+from ehrql.tables.tpp import practice_registrations as registrations
 from ehrql import create_dataset
-from ehrql.tables.tpp import patients, practice_registrations
 
 dataset = create_dataset()
+parser = argparse.ArgumentParser()
+parser.add_argument("--codelist")
+args = parser.parse_args()
+start_date = "2020-03-31"
+end_date = "2021-03-31"
 
-index_date = "2020-03-31"
+# Codelists
+# --------------------------------------------------------------------------------------
+codelist = codelist_from_csv(args.codelist, column="code")
+codelist_events = events.where(
+    events.snomedct_code.is_in(codelist)
+    & events.date.is_on_or_between(start_date, end_date)
+)
 
-has_registration = practice_registrations.for_patient_on(
-    index_date
-).exists_for_patient()
+dataset.region = registrations.for_patient_on(start_date).practice_nuts1_region_name
 
-dataset.define_population(has_registration)
+dataset.codelist_event_count = codelist_events.count_for_patient()
 
-dataset.sex = patients.sex
+dataset.test_value_count = codelist_events.where(
+    events.numeric_value.is_not_null()
+).count_for_patient()
+
+dataset.define_population(patients.exists_for_patient())
+

--- a/analysis/measure_definition.py
+++ b/analysis/measure_definition.py
@@ -1,0 +1,42 @@
+import argparse
+from ehrql import INTERVAL, Measures, codelist_from_csv, years
+from ehrql.tables.core import clinical_events as events
+from ehrql.tables.tpp import practice_registrations as registrations
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--codelist")
+args = parser.parse_args()
+index_date = "2018-01-01"
+
+# Codelists
+codelist = codelist_from_csv(args.codelist, column="code")
+codelist_events = events.where(
+    events.snomedct_code.is_in(codelist) & events.date.is_during(INTERVAL)
+)
+
+# Stratification variables
+region = registrations.for_patient_on(INTERVAL.start_date).practice_nuts1_region_name
+
+# Presence of codelist (denominator)
+codelist_event_count = codelist_events.count_for_patient()
+
+# Non-null test value count
+test_value_count = codelist_events.where(
+    events.numeric_value.is_not_null()
+).count_for_patient()
+
+
+# Measures
+# --------------------------------------------------------------------------------------
+measures = Measures()
+measures.configure_dummy_data(population_size=1000, legacy=True)
+measures.define_defaults(denominator=codelist_event_count)
+
+intervals = years(7).starting_on(index_date)
+measures.define_measure(
+    name="test_value_present",
+    numerator=test_value_count,
+    intervals=intervals,
+    group_by={"region": region},
+)
+

--- a/analysis/test_dataset_definition.py
+++ b/analysis/test_dataset_definition.py
@@ -1,0 +1,21 @@
+from datetime import date
+
+from analysis.dataset_definition import dataset  # noqa: F401
+
+test_data = {
+    1: {
+        "clinical_events": [
+            {
+                "numeric_value": 7,
+                "snomedct_code": "1013211000000103",
+                "date": date(2020, 4, 1),
+            },
+            {"snomedct_code": "1013211000000103", "date": date(2020, 4, 1)},
+        ],
+        "patients": {},
+        "practice_registrations": {},
+        "expected_in_population": True,
+        "expected_columns": {"codelist_event_count": 2, "test_value_count": 1},
+    }
+}
+

--- a/codelists/codelists.json
+++ b/codelists/codelists.json
@@ -1,3 +1,28 @@
 {
-  "files": {}
+  "files": {
+    "opensafely-alanine-aminotransferase-alt-tests.csv": {
+      "id": "opensafely/alanine-aminotransferase-alt-tests/2298df3e",
+      "url": "https://www.opencodelists.org/codelist/opensafely/alanine-aminotransferase-alt-tests/2298df3e/",
+      "downloaded_at": "2025-02-18 10:12:06.111109Z",
+      "sha": "0d231653e5ece343f6945309d21fc40c7f685ff2"
+    },
+    "opensafely-cholesterol-tests.csv": {
+      "id": "opensafely/cholesterol-tests/62eb0940",
+      "url": "https://www.opencodelists.org/codelist/opensafely/cholesterol-tests/62eb0940/",
+      "downloaded_at": "2025-02-18 10:12:06.256688Z",
+      "sha": "e5f9e7e0b44c18830aea207f001d015153a56b8e"
+    },
+    "opensafely-red-blood-cell-rbc-tests.csv": {
+      "id": "opensafely/red-blood-cell-rbc-tests/17bcafa1",
+      "url": "https://www.opencodelists.org/codelist/opensafely/red-blood-cell-rbc-tests/17bcafa1/",
+      "downloaded_at": "2025-02-18 10:12:06.420481Z",
+      "sha": "e111693c2b9ae4e688d859daa73491a978b0795b"
+    },
+    "opensafely-glycated-haemoglobin-hba1c-tests.csv": {
+      "id": "opensafely/glycated-haemoglobin-hba1c-tests/30cc22d6",
+      "url": "https://www.opencodelists.org/codelist/opensafely/glycated-haemoglobin-hba1c-tests/30cc22d6/",
+      "downloaded_at": "2025-02-18 10:12:06.559242Z",
+      "sha": "fb9a968b5644c14c570bf2b8708381600f4bd1f5"
+    }
+  }
 }

--- a/codelists/codelists.txt
+++ b/codelists/codelists.txt
@@ -1,0 +1,4 @@
+opensafely/alanine-aminotransferase-alt-tests/2298df3e
+opensafely/cholesterol-tests/62eb0940/
+opensafely/red-blood-cell-rbc-tests/17bcafa1/
+opensafely/glycated-haemoglobin-hba1c-tests/30cc22d6/

--- a/codelists/opensafely-alanine-aminotransferase-alt-tests.csv
+++ b/codelists/opensafely-alanine-aminotransferase-alt-tests.csv
@@ -1,0 +1,14 @@
+code,term
+1013211000000103,Plasma alanine aminotransferase level
+1018251000000107,Serum alanine aminotransferase level
+104481004,"Alanine aminotransferase measurement, method with pyridoxal-5'-phosphate"
+104482006,"Alanine aminotransferase measurement, method without pyridoxal-5'-phosphate"
+201321000000108,Serum alanine aminotransferase level
+219651000000107,Serum alanine aminotransferase level
+219661000000105,Serum alanine aminotransferase level
+250637003,Alanine aminotransferase - blood measurement
+34608000,Alanine aminotransferase measurement
+389586005,Plasma alanine aminotransferase level
+390318006,Plasma alanine aminotransferase level
+390961000,Plasma alanine aminotransferase level
+889391000000100,Measurement of alanine transaminase activity

--- a/codelists/opensafely-cholesterol-tests.csv
+++ b/codelists/opensafely-cholesterol-tests.csv
@@ -1,0 +1,17 @@
+code,term
+1005671000000105,Serum cholesterol level
+1017161000000104,Plasma total cholesterol level
+114711000000101,Serum total cholesterol level
+119291000000100,Serum total cholesterol level
+270996006,Serum cholesterol measurement
+365793008,Finding of cholesterol level
+365794002,Finding of serum cholesterol level
+389608004,Plasma total cholesterol level
+390340002,Plasma total cholesterol level
+390956002,Plasma total cholesterol level
+393025009,Pre-treatment serum cholesterol level
+393981000,Pre-treatment serum cholesterol level
+395153009,Pre-treatment serum cholesterol level
+412808005,Serum total cholesterol measurement
+850981000000101,Cholesterol level
+853681000000104,Total cholesterol level

--- a/codelists/opensafely-glycated-haemoglobin-hba1c-tests.csv
+++ b/codelists/opensafely-glycated-haemoglobin-hba1c-tests.csv
@@ -1,0 +1,11 @@
+code,term
+1003671000000109,Haemoglobin A1c level
+144176003,Haemoglobin A1c level
+166902009,Haemoglobin A1c level
+313835008,Hemoglobin A1c measurement aligned to the Diabetes Control and Complications Trial
+365845005,Hemoglobin A1C - diabetic control finding
+371981000000106,Haemoglobin A1c measurement - International Federation of Clinical Chemistry and Laboratory Medicine standardised
+43396009,Hemoglobin A1c measurement
+491841000000105,Haemoglobin A1c level
+567641000000108,Haemoglobin A1C - diabetic control NOS
+999791000000106,Haemoglobin A1c level - International Federation of Clinical Chemistry and Laboratory Medicine standardised

--- a/codelists/opensafely-red-blood-cell-rbc-tests.csv
+++ b/codelists/opensafely-red-blood-cell-rbc-tests.csv
@@ -1,0 +1,7 @@
+code,term
+1022451000000103,Red blood cell count
+14089001,Red blood cell count
+142831004,Red blood cell count
+165428005,Red blood cell count NOS
+365625004,Finding of red blood cell count
+537891000000106,Red blood cell count NOS

--- a/project.yaml
+++ b/project.yaml
@@ -1,8 +1,59 @@
-version: '4.0'
+version: "4.0"
 
 actions:
-  generate_dataset:
-    run: ehrql:v1 generate-dataset analysis/dataset_definition.py --output output/dataset.csv.gz
+  generate_measures_alt:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/measures_alt.csv
+        --
+        --codelist codelists/opensafely-alanine-aminotransferase-alt-tests.csv
+    outputs:
+      moderately_sensitive:
+        measures: output/measures_alt.csv
+
+  generate_measures_chol:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/measures_chol.csv
+        --
+        --codelist codelists/opensafely-cholesterol-tests.csv
+    outputs:
+      moderately_sensitive:
+        measures: output/measures_chol.csv
+
+  generate_measures_hba1c:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/measures_hba1c.csv
+        --
+        --codelist codelists/opensafely-glycated-haemoglobin-hba1c-tests.csv
+    outputs:
+      moderately_sensitive:
+        measures: output/measures_hba1c.csv
+
+  generate_measures_rbc:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/measures_rbc.csv
+        --
+        --codelist codelists/opensafely-red-blood-cell-rbc-tests.csv
+    outputs:
+      moderately_sensitive:
+        measures: output/measures_rbc.csv
+
+  # Runs test to ensure correctness of measures queries
+  generate_test_dataset:
+    run: >
+      ehrql:v1 generate-dataset
+        analysis/dataset_definition.py
+        --output output/test_dataset.csv
+        --test-data-file analysis/test_dataset_definition.py
+        --
+        --codelist codelists/opensafely-alanine-aminotransferase-alt-tests.csv
     outputs:
       highly_sensitive:
-        dataset: output/dataset.csv.gz
+        dataset: output/test_dataset.csv


### PR DESCRIPTION
We're separating OpenPathology into two repositories:

* [opensafely/open-pathology][] contains the dashboards and associated measure definitions. As a research project, it must have a COVID focus.
* [opensafely/open-pathology-sdr][] (this repository) contains the short data report. As a short data report project it need not have a COVID focus.

For more information about research projects and short data report projects, please see the "[OpenSAFELY Data Access Policy][1]" page.

This PR mirrors opensafely/open-pathology#36.

[1]: https://docs.opensafely.org/data-access-policy/
[opensafely/open-pathology]: https://github.com/opensafely/open-pathology
[opensafely/open-pathology-sdr]: https://github.com/opensafely/open-pathology-sdr