### PR TITLE
Include comparators and reference ranges

### DIFF
--- a/analysis/dataset_definition.py
+++ b/analysis/dataset_definition.py
@@ -3,9 +3,11 @@
 
 import argparse
 from ehrql import codelist_from_csv
-from ehrql.tables.core import clinical_events as events
 from ehrql.tables.core import patients
-from ehrql.tables.tpp import practice_registrations as registrations
+from ehrql.tables.tpp import (
+    practice_registrations as registrations,
+    clinical_events_ranges as ranges,
+)
 from ehrql import create_dataset
 
 dataset = create_dataset()
@@ -17,19 +19,52 @@ end_date = "2021-03-31"
 
 # Codelists
 # --------------------------------------------------------------------------------------
+
+# Codelists
 codelist = codelist_from_csv(args.codelist, column="code")
-codelist_events = events.where(
-    events.snomedct_code.is_in(codelist)
-    & events.date.is_on_or_between(start_date, end_date)
+codelist_events = ranges.where(
+    ranges.snomedct_code.is_in(codelist)
+    & ranges.date.is_on_or_between(start_date, end_date)
 )
 
-dataset.region = registrations.for_patient_on(start_date).practice_nuts1_region_name
+# Stratification variables
+region = registrations.for_patient_on(start_date).practice_nuts1_region_name
 
-dataset.codelist_event_count = codelist_events.count_for_patient()
+# Presence of codelist (denominator)
+codelist_event_count = codelist_events.count_for_patient()
 
-dataset.test_value_count = codelist_events.where(
-    events.numeric_value.is_not_null()
-).count_for_patient()
+# Booleans
+has_test_value = ranges.numeric_value.is_not_null()
+has_equality_comparator = ranges.comparator.is_in(["=", "~"])
+has_differential_comparator = ranges.comparator.is_not_null() & ~has_equality_comparator
+has_upper_bound = ranges.upper_bound.is_not_null()
+has_lower_bound = ranges.lower_bound.is_not_null()
+
+# Generate all combinations of test_value, equality_comparator, differential_comparator, upper_bound, and lower_bound
+# E.g. valT_equalT_diffF_uppT_lowF
+count_measures = dict()
+for value in [True, False]:
+    # Use zip to exclude equal_compT, diff_compT (since both can't be true)
+    for equal_comp, diff_comp in zip([True, False, False], [False, True, False]):
+        for upper in [True, False]:
+            for lower in [True, False]:
+                key = f"val{'T' if value else 'F'}_equal{'T' if equal_comp else 'F'}_diff{'T' if diff_comp else 'F'}_upp{'T' if upper else 'F'}_low{'T' if lower else 'F'}"
+                count_measures[key] = codelist_events.where(
+                    (has_test_value if value else ~has_test_value)
+                    & (
+                        has_equality_comparator
+                        if equal_comp
+                        else ~has_equality_comparator
+                    )
+                    & (
+                        has_differential_comparator
+                        if diff_comp
+                        else ~has_differential_comparator
+                    )
+                    & (has_upper_bound if upper else ~has_upper_bound)
+                    & (has_lower_bound if lower else ~has_lower_bound)
+                ).count_for_patient()
+                dataset.add_column(key, count_measures[key])
 
 dataset.define_population(patients.exists_for_patient())
 

--- a/analysis/measure_definition.py
+++ b/analysis/measure_definition.py
@@ -1,6 +1,6 @@
 import argparse
 from ehrql import INTERVAL, Measures, codelist_from_csv, years
-from ehrql.tables.core import clinical_events as events
+from ehrql.tables.tpp import clinical_events_ranges as ranges
 from ehrql.tables.tpp import practice_registrations as registrations
 
 parser = argparse.ArgumentParser()
@@ -10,8 +10,8 @@ index_date = "2018-01-01"
 
 # Codelists
 codelist = codelist_from_csv(args.codelist, column="code")
-codelist_events = events.where(
-    events.snomedct_code.is_in(codelist) & events.date.is_during(INTERVAL)
+codelist_events = ranges.where(
+    ranges.snomedct_code.is_in(codelist) & ranges.date.is_during(INTERVAL)
 )
 
 # Stratification variables
@@ -20,23 +20,49 @@ region = registrations.for_patient_on(INTERVAL.start_date).practice_nuts1_region
 # Presence of codelist (denominator)
 codelist_event_count = codelist_events.count_for_patient()
 
-# Non-null test value count
-test_value_count = codelist_events.where(
-    events.numeric_value.is_not_null()
-).count_for_patient()
+# Booleans
+has_test_value = ranges.numeric_value.is_not_null()
+has_equality_comparator = ranges.comparator.is_in(["=", "~"])
+has_differential_comparator = ranges.comparator.is_not_null() & ~has_equality_comparator
+has_upper_bound = ranges.upper_bound.is_not_null()
+has_lower_bound = ranges.lower_bound.is_not_null()
 
-
+# Generate all combinations of test_value, equality_comparator, differential_comparator, upper_bound, and lower_bound
+# E.g. valT_equalT_diffF_uppT_lowF
+count_measures = dict()
+for value in [True, False]:
+    # Use zip to exclude equal_compT, diff_compT (since both can't be true)
+    for equal_comp, diff_comp in zip([True, False, False], [False, True, False]):
+        for upper in [True, False]:
+            for lower in [True, False]:
+                key = f"val{'T' if value else 'F'}_equal{'T' if equal_comp else 'F'}_diff{'T' if diff_comp else 'F'}_upp{'T' if upper else 'F'}_low{'T' if lower else 'F'}"
+                count_measures[key] = codelist_events.where(
+                    (has_test_value if value else ~has_test_value)
+                    & (
+                        has_equality_comparator
+                        if equal_comp
+                        else ~has_equality_comparator
+                    )
+                    & (
+                        has_differential_comparator
+                        if diff_comp
+                        else ~has_differential_comparator
+                    )
+                    & (has_upper_bound if upper else ~has_upper_bound)
+                    & (has_lower_bound if lower else ~has_lower_bound)
+                ).count_for_patient()
 # Measures
 # --------------------------------------------------------------------------------------
 measures = Measures()
 measures.configure_dummy_data(population_size=1000, legacy=True)
-measures.define_defaults(denominator=codelist_event_count)
-
-intervals = years(7).starting_on(index_date)
-measures.define_measure(
-    name="test_value_present",
-    numerator=test_value_count,
-    intervals=intervals,
+measures.define_defaults(
+    denominator=codelist_event_count,
+    intervals=years(7).starting_on(index_date),
     group_by={"region": region},
 )
 
+for m, numerator in count_measures.items():
+    measures.define_measure(
+        name=m,
+        numerator=numerator,
+    )

--- a/analysis/test_dataset_definition.py
+++ b/analysis/test_dataset_definition.py
@@ -4,18 +4,31 @@ from analysis.dataset_definition import dataset  # noqa: F401
 
 test_data = {
     1: {
-        "clinical_events": [
+        "clinical_events_ranges": [
             {
-                "numeric_value": 7,
+                "numeric_value": 30,
                 "snomedct_code": "1013211000000103",
                 "date": date(2020, 4, 1),
+                "lower_bound": 23,
+                "upper_bound": 76,
+                "comparator": "<",
             },
-            {"snomedct_code": "1013211000000103", "date": date(2020, 4, 1)},
+            {
+                "numeric_value": 30,
+                "snomedct_code": "1013211000000103",
+                "date": date(2020, 4, 1),
+                "lower_bound": 23,
+                "upper_bound": 76,
+                "comparator": "~",
+            },
         ],
-        "patients": {},
+        "patients": {"sex": "male"},
         "practice_registrations": {},
         "expected_in_population": True,
-        "expected_columns": {"codelist_event_count": 2, "test_value_count": 1},
+        "expected_columns": {
+            "valT_equalF_diffT_uppT_lowT": 1,
+            "valT_equalT_diffF_uppT_lowT": 1,
+        },
     }
 }
 


### PR DESCRIPTION
This updates the measure definition to include comparators and reference ranges. It mirrors opensafely/open-pathology#37.

For more information about why we have mirrored PRs, please see opensafely/open-pathology#39.