### PR TITLE
Reducing and parallelizing measures extraction

### DIFF
--- a/generate_yaml.py
+++ b/generate_yaml.py
@@ -1,0 +1,72 @@
+"""
+Description: 
+- This script generates the YAML file for the project.
+
+Usage:
+- python generate_yaml.py
+
+Output:
+- project.yaml
+"""
+
+from datetime import datetime, timedelta
+
+# --- YAML HEADER ---
+
+yaml_header = """
+version: '4.0'
+
+actions:
+"""
+
+# --- YAML MEASURES BODY ----
+
+
+# Template for measures generation
+yaml_template = """
+  generate_measures_{test}_{measure}:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/measures_{test}_{measure}.csv
+        --
+        --codelist {codelist_path}
+        --measure {measure}
+    outputs:
+      moderately_sensitive:
+        measures: output/measures_{test}_{measure}.csv
+"""
+
+yaml_body = ""
+needs = {}
+codelists = {'alt': 'codelists/opensafely-alanine-aminotransferase-alt-tests.csv',
+             'chol': 'codelists/opensafely-cholesterol-tests.csv',
+             'hba1c': 'codelists/opensafely-glycated-haemoglobin-hba1c-tests.csv', 
+             'rbc': 'codelists/opensafely-red-blood-cell-rbc-tests.csv', 
+             'sodium': 'codelists/opensafely-sodium-tests-numerical-value.csv'}
+measures = ['has_test_value', 'has_equality_comparator', 'has_differential_comparator',
+            'has_lower_bound', 'has_upper_bound']
+
+for test, path in codelists.items():
+
+    for measure in measures:
+        yaml_body += yaml_template.format(test = test, codelist_path = path, measure = measure)
+
+# ---- YAML TESTS ------
+yaml_test = '''
+  # Runs test to ensure correctness of measures queries
+  generate_test_dataset:
+    run: >
+      ehrql:v1 generate-dataset
+        analysis/dataset_definition.py
+        --output output/test_dataset.csv
+        --test-data-file analysis/test_dataset_definition.py
+        --
+        --codelist codelists/opensafely-alanine-aminotransferase-alt-tests.csv
+    outputs:
+      highly_sensitive:
+        dataset: output/test_dataset.csv
+'''
+yaml = yaml_header + yaml_body + yaml_test
+with open("project.yaml", "w") as file:
+       file.write(yaml)

--- a/project.yaml
+++ b/project.yaml
@@ -1,60 +1,307 @@
-version: "4.0"
+
+version: '4.0'
 
 actions:
-  generate_measures_alt:
+
+  generate_measures_alt_has_test_value:
     run: >
       ehrql:v1 generate-measures
         analysis/measure_definition.py
-        --output output/measures_alt.csv
+        --output output/measures_alt_has_test_value.csv
         --
         --codelist codelists/opensafely-alanine-aminotransferase-alt-tests.csv
+        --measure has_test_value
     outputs:
       moderately_sensitive:
-        measures: output/measures_alt.csv
+        measures: output/measures_alt_has_test_value.csv
 
-  generate_measures_chol:
+  generate_measures_alt_has_equality_comparator:
     run: >
       ehrql:v1 generate-measures
         analysis/measure_definition.py
-        --output output/measures_chol.csv
+        --output output/measures_alt_has_equality_comparator.csv
+        --
+        --codelist codelists/opensafely-alanine-aminotransferase-alt-tests.csv
+        --measure has_equality_comparator
+    outputs:
+      moderately_sensitive:
+        measures: output/measures_alt_has_equality_comparator.csv
+
+  generate_measures_alt_has_differential_comparator:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/measures_alt_has_differential_comparator.csv
+        --
+        --codelist codelists/opensafely-alanine-aminotransferase-alt-tests.csv
+        --measure has_differential_comparator
+    outputs:
+      moderately_sensitive:
+        measures: output/measures_alt_has_differential_comparator.csv
+
+  generate_measures_alt_has_lower_bound:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/measures_alt_has_lower_bound.csv
+        --
+        --codelist codelists/opensafely-alanine-aminotransferase-alt-tests.csv
+        --measure has_lower_bound
+    outputs:
+      moderately_sensitive:
+        measures: output/measures_alt_has_lower_bound.csv
+
+  generate_measures_alt_has_upper_bound:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/measures_alt_has_upper_bound.csv
+        --
+        --codelist codelists/opensafely-alanine-aminotransferase-alt-tests.csv
+        --measure has_upper_bound
+    outputs:
+      moderately_sensitive:
+        measures: output/measures_alt_has_upper_bound.csv
+
+  generate_measures_chol_has_test_value:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/measures_chol_has_test_value.csv
         --
         --codelist codelists/opensafely-cholesterol-tests.csv
+        --measure has_test_value
     outputs:
       moderately_sensitive:
-        measures: output/measures_chol.csv
+        measures: output/measures_chol_has_test_value.csv
 
-  generate_measures_hba1c:
+  generate_measures_chol_has_equality_comparator:
     run: >
       ehrql:v1 generate-measures
         analysis/measure_definition.py
-        --output output/measures_hba1c.csv
+        --output output/measures_chol_has_equality_comparator.csv
+        --
+        --codelist codelists/opensafely-cholesterol-tests.csv
+        --measure has_equality_comparator
+    outputs:
+      moderately_sensitive:
+        measures: output/measures_chol_has_equality_comparator.csv
+
+  generate_measures_chol_has_differential_comparator:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/measures_chol_has_differential_comparator.csv
+        --
+        --codelist codelists/opensafely-cholesterol-tests.csv
+        --measure has_differential_comparator
+    outputs:
+      moderately_sensitive:
+        measures: output/measures_chol_has_differential_comparator.csv
+
+  generate_measures_chol_has_lower_bound:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/measures_chol_has_lower_bound.csv
+        --
+        --codelist codelists/opensafely-cholesterol-tests.csv
+        --measure has_lower_bound
+    outputs:
+      moderately_sensitive:
+        measures: output/measures_chol_has_lower_bound.csv
+
+  generate_measures_chol_has_upper_bound:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/measures_chol_has_upper_bound.csv
+        --
+        --codelist codelists/opensafely-cholesterol-tests.csv
+        --measure has_upper_bound
+    outputs:
+      moderately_sensitive:
+        measures: output/measures_chol_has_upper_bound.csv
+
+  generate_measures_hba1c_has_test_value:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/measures_hba1c_has_test_value.csv
         --
         --codelist codelists/opensafely-glycated-haemoglobin-hba1c-tests.csv
+        --measure has_test_value
     outputs:
       moderately_sensitive:
-        measures: output/measures_hba1c.csv
+        measures: output/measures_hba1c_has_test_value.csv
 
-  generate_measures_rbc:
+  generate_measures_hba1c_has_equality_comparator:
     run: >
       ehrql:v1 generate-measures
         analysis/measure_definition.py
-        --output output/measures_rbc.csv
+        --output output/measures_hba1c_has_equality_comparator.csv
+        --
+        --codelist codelists/opensafely-glycated-haemoglobin-hba1c-tests.csv
+        --measure has_equality_comparator
+    outputs:
+      moderately_sensitive:
+        measures: output/measures_hba1c_has_equality_comparator.csv
+
+  generate_measures_hba1c_has_differential_comparator:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/measures_hba1c_has_differential_comparator.csv
+        --
+        --codelist codelists/opensafely-glycated-haemoglobin-hba1c-tests.csv
+        --measure has_differential_comparator
+    outputs:
+      moderately_sensitive:
+        measures: output/measures_hba1c_has_differential_comparator.csv
+
+  generate_measures_hba1c_has_lower_bound:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/measures_hba1c_has_lower_bound.csv
+        --
+        --codelist codelists/opensafely-glycated-haemoglobin-hba1c-tests.csv
+        --measure has_lower_bound
+    outputs:
+      moderately_sensitive:
+        measures: output/measures_hba1c_has_lower_bound.csv
+
+  generate_measures_hba1c_has_upper_bound:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/measures_hba1c_has_upper_bound.csv
+        --
+        --codelist codelists/opensafely-glycated-haemoglobin-hba1c-tests.csv
+        --measure has_upper_bound
+    outputs:
+      moderately_sensitive:
+        measures: output/measures_hba1c_has_upper_bound.csv
+
+  generate_measures_rbc_has_test_value:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/measures_rbc_has_test_value.csv
         --
         --codelist codelists/opensafely-red-blood-cell-rbc-tests.csv
+        --measure has_test_value
     outputs:
       moderately_sensitive:
-        measures: output/measures_rbc.csv
+        measures: output/measures_rbc_has_test_value.csv
 
-  generate_measures_sodium:
+  generate_measures_rbc_has_equality_comparator:
     run: >
       ehrql:v1 generate-measures
         analysis/measure_definition.py
-        --output output/measures_sodium.csv
+        --output output/measures_rbc_has_equality_comparator.csv
         --
-        --codelist codelists/opensafely-sodium-tests-numerical-value.csv
+        --codelist codelists/opensafely-red-blood-cell-rbc-tests.csv
+        --measure has_equality_comparator
     outputs:
       moderately_sensitive:
-        measures: output/measures_sodium.csv
+        measures: output/measures_rbc_has_equality_comparator.csv
+
+  generate_measures_rbc_has_differential_comparator:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/measures_rbc_has_differential_comparator.csv
+        --
+        --codelist codelists/opensafely-red-blood-cell-rbc-tests.csv
+        --measure has_differential_comparator
+    outputs:
+      moderately_sensitive:
+        measures: output/measures_rbc_has_differential_comparator.csv
+
+  generate_measures_rbc_has_lower_bound:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/measures_rbc_has_lower_bound.csv
+        --
+        --codelist codelists/opensafely-red-blood-cell-rbc-tests.csv
+        --measure has_lower_bound
+    outputs:
+      moderately_sensitive:
+        measures: output/measures_rbc_has_lower_bound.csv
+
+  generate_measures_rbc_has_upper_bound:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/measures_rbc_has_upper_bound.csv
+        --
+        --codelist codelists/opensafely-red-blood-cell-rbc-tests.csv
+        --measure has_upper_bound
+    outputs:
+      moderately_sensitive:
+        measures: output/measures_rbc_has_upper_bound.csv
+
+  generate_measures_sodium_has_test_value:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/measures_sodium_has_test_value.csv
+        --
+        --codelist codelists/opensafely-sodium-tests-numerical-value.csv
+        --measure has_test_value
+    outputs:
+      moderately_sensitive:
+        measures: output/measures_sodium_has_test_value.csv
+
+  generate_measures_sodium_has_equality_comparator:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/measures_sodium_has_equality_comparator.csv
+        --
+        --codelist codelists/opensafely-sodium-tests-numerical-value.csv
+        --measure has_equality_comparator
+    outputs:
+      moderately_sensitive:
+        measures: output/measures_sodium_has_equality_comparator.csv
+
+  generate_measures_sodium_has_differential_comparator:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/measures_sodium_has_differential_comparator.csv
+        --
+        --codelist codelists/opensafely-sodium-tests-numerical-value.csv
+        --measure has_differential_comparator
+    outputs:
+      moderately_sensitive:
+        measures: output/measures_sodium_has_differential_comparator.csv
+
+  generate_measures_sodium_has_lower_bound:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/measures_sodium_has_lower_bound.csv
+        --
+        --codelist codelists/opensafely-sodium-tests-numerical-value.csv
+        --measure has_lower_bound
+    outputs:
+      moderately_sensitive:
+        measures: output/measures_sodium_has_lower_bound.csv
+
+  generate_measures_sodium_has_upper_bound:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/measures_sodium_has_upper_bound.csv
+        --
+        --codelist codelists/opensafely-sodium-tests-numerical-value.csv
+        --measure has_upper_bound
+    outputs:
+      moderately_sensitive:
+        measures: output/measures_sodium_has_upper_bound.csv
 
   # Runs test to ensure correctness of measures queries
   generate_test_dataset:


### PR DESCRIPTION
Closes #4 
- Removed measures that checked multiple fields at once, leaving only measures that check a single field.
   - E.g. Removed (has_test_value & has_upper_bound &...), kept (has_test_value)
   - This reduces the number of measures from ~24 to 5.
- Split measures extraction across actions, so each action generates an extract for a specific codelist and specific field e.g. generate_alt_has_test_value
   - Since there are lots of actions now (5 codelists * 5 actions = 25), `generate_yaml.py` was added to automate yaml.py generation.
- Reduced number of years to 1 for initial test extractions