### PR TITLE
Add histograms for upper/lower bounds

### DIFF
--- a/analysis/proxy_null_analysis/generate_histogram.r
+++ b/analysis/proxy_null_analysis/generate_histogram.r
@@ -4,61 +4,49 @@ library(scales)
 library(glue)
 source("analysis/proxy_null_analysis/config.r") # Provides opt$codelist and test variables
 
-if (opt$test_run){
-  # Set seed for reproducibility
-  set.seed(123)
-  # Parameters
-  mu <- 13         # Mean (expected count)
-  theta <- 3       # Dispersion parameter: smaller = more overdispersed
-  n <- 50000         # Sample size
-  sim_data <- rnbinom(n, size = theta, mu = mu)
-  # Tabulate and convert to data frame
-  top_1000 <- as.data.frame(table(sim_data))
-  # Rename columns for clarity
-  colnames(top_1000) <- c("value", "count_midpoint6")
-  top_1000[top_1000$value == 0, ]$count_midpoint6 <- top_1000[top_1000$value == 0, ]$count_midpoint6 + 1000
-  # Convert 'value' from factor to numeric
-  top_1000$value <- as.numeric(as.character(top_1000$value))
-  # Show first few values
-  print(head(top_1000))
-} else {
-  top_1000 <- read.csv(glue('output/{test}/proxy_null/top_1000_numeric_values_{test}.csv'))
+fields <- c("numeric_value", "lower_bound", "upper_bound")
+for (field in fields){
+
+  if (opt$test_run){
+    # Set seed for reproducibility
+    set.seed(123)
+    # Parameters
+    mu <- 13         # Mean (expected count)
+    theta <- 3       # Dispersion parameter: smaller = more overdispersed
+    n <- 50000         # Sample size
+    sim_data <- rnbinom(n, size = theta, mu = mu)
+    # Tabulate and convert to data frame
+    top_1000 <- as.data.frame(table(sim_data))
+    # Rename columns for clarity
+    colnames(top_1000) <- c("value", "count_midpoint6")
+    top_1000[top_1000$value == 0, ]$count_midpoint6 <- top_1000[top_1000$value == 0, ]$count_midpoint6 + 1000
+    # Convert 'value' from factor to numeric
+    top_1000$value <- as.numeric(as.character(top_1000$value))
+    # Show first few values
+    print(head(top_1000))
+  } else {
+    top_1000 <- read.csv(glue('output/{test}/proxy_null/top_1000_{field}_{test}.csv'))
+  }
+
+  # Round floats to nearest integer (i.e. binning)
+  top_1000$value <- round(top_1000$value)
+
+  # Aggregate to get propn per integer
+  aggregated_top_1000 <- top_1000 %>%
+    group_by(value) %>%
+    summarise(total_propn_midpoint6 = sum(propn_midpoint6), .groups = "drop")
+
+  # Generate histogram
+  p <- ggplot(aggregated_top_1000, aes(x = value, y = total_propn_midpoint6)) +
+    geom_bar(stat = "identity", 
+            fill = "lightblue", 
+            color = "black", 
+            alpha = 0.7) +
+    scale_x_continuous(limits = c(min(aggregated_top_1000$value) - 2, max(aggregated_top_1000$value) + 2)) +
+    scale_y_continuous(labels = label_comma()) + # this line disables scientific notation
+    labs(title = glue("Histogram of top 1000 {field} values for {test}"), 
+        x = field, 
+        y = "Propn")
+
+  ggsave(glue("output/{test}/proxy_null/{field}_{test}.png"), plot = p)
 }
-
-# Round floats to nearest integer (i.e. binning)
-top_1000$value <- round(top_1000$value)
-reconstructed <- rep(as.numeric(as.character(top_1000$value)), top_1000$count_midpoint6)
-upper_quartile <- as.numeric(quantile(reconstructed, probs = 0.95))
-
-# Aggregate to get counts per integer
-aggregated_top_1000 <- top_1000 %>%
-  group_by(value) %>%
-  summarise(total_count_midpoint6_derived = sum(count_midpoint6), .groups = "drop")
-
-# Generate histogram
-p <- ggplot(aggregated_top_1000, aes(x = value, y = total_count_midpoint6_derived)) +
-  geom_bar(stat = "identity", 
-           fill = "lightblue", 
-           color = "black", 
-           alpha = 0.7) +
-  scale_x_continuous(limits = c(min(aggregated_top_1000$value) - 2, max(aggregated_top_1000$value) + 2)) +
-  scale_y_continuous(labels = label_comma()) + # this line disables scientific notation
-  labs(title = glue("Histogram of top 1000 numeric values for {test}"), 
-       x = "numeric_value", 
-       y = "Count")
-
-# Generate zoomed-in histogram
-pp <- ggplot(aggregated_top_1000, aes(x = value, y = total_count_midpoint6_derived)) +
-  geom_bar(stat = "identity", 
-           fill = "lightblue", 
-           color = "black", 
-           alpha = 0.7) +
-  scale_x_continuous(limits = c(min(aggregated_top_1000$value) - 2, upper_quartile)) +
-  scale_y_continuous(labels = label_comma()) + 
-  labs(title = glue("Histogram of top 1000 numeric values for {test}, zoomed"), 
-       x = "numeric_value", 
-       y = "Count")
-
-ggsave(glue("output/{test}/proxy_null/numeric_values_{test}.png"), plot = p)
-ggsave(glue("output/{test}/proxy_null/numeric_values_zoomed_{test}.png"), plot = pp)
- 

--- a/analysis/proxy_null_analysis/value_dataset_definition.py
+++ b/analysis/proxy_null_analysis/value_dataset_definition.py
@@ -1,11 +1,12 @@
-# This script extracts numeric values for testing if there are proxy null values
+# This script extracts numeric, upper and lower bound values for testing if there are proxy null values
+# Args: --codelist [codelist]
 
 import argparse
 from ehrql import codelist_from_csv
 from ehrql.tables.core import patients
 from ehrql.tables.tpp import (
     practice_registrations as registrations,
-    clinical_events
+    clinical_events_ranges
 )
 from ehrql import create_dataset
 
@@ -21,14 +22,17 @@ end_date = "2024-01-01"
 
 # Codelists
 codelist = codelist_from_csv(args.codelist, column="code")
-codelist_events = clinical_events.where(
-    clinical_events.snomedct_code.is_in(codelist)
-    & clinical_events.date.is_on_or_between(start_date, end_date)
+
+codelist_events = clinical_events_ranges.where(
+    clinical_events_ranges.snomedct_code.is_in(codelist)
+    & clinical_events_ranges.date.is_on_or_between(start_date, end_date)
 )
 
 # Extract numeric values for codelist
 dataset.codelist_event_count = codelist_events.count_for_patient()
 dataset.numeric_value = codelist_events.sort_by(codelist_events.date).first_for_patient().numeric_value
+dataset.upper_bound = codelist_events.sort_by(codelist_events.date).first_for_patient().upper_bound
+dataset.lower_bound = codelist_events.sort_by(codelist_events.date).first_for_patient().lower_bound
 
 dataset.configure_dummy_data(population_size=1000)
 dataset.define_population(patients.exists_for_patient())

--- a/generate_yaml.py
+++ b/generate_yaml.py
@@ -40,40 +40,32 @@ yaml_measure_template = """
 yaml_body_template = """
 # ----------------- Test: {test} ---------------------------------
 
-  generate_numeric_value_dataset_{test}:
+  generate_value_dataset_{test}:
     run: >
       ehrql:v1 generate-dataset
-        analysis/proxy_null_analysis/numeric_value_dataset_definition.py
-        --output output/{test}/proxy_null/numeric_value_dataset_{test}.csv
+        analysis/proxy_null_analysis/value_dataset_definition.py
+        --output output/{test}/proxy_null/value_dataset_{test}.csv
         --
         --codelist {path}
     outputs:
       highly_sensitive:
-        dataset: output/{test}/proxy_null/numeric_value_dataset_{test}.csv
-  generate_numeric_value_table_{test}:
+        dataset: output/{test}/proxy_null/value_dataset_{test}.csv
+  generate_value_table_{test}:
     run: >
       r:latest analysis/proxy_null_analysis/generate_freq_table.r 
       --codelist {path}
-    needs: [generate_numeric_value_dataset_{test}]
+    needs: [generate_value_dataset_{test}]
     outputs:
       moderately_sensitive:
-        dataset: output/{test}/proxy_null/top_1000_numeric_values_{test}.csv
+        dataset: output/{test}/proxy_null/top_1000_*_{test}.csv
   generate_numeric_value_histogram_{test}:
     run: >
       r:latest analysis/proxy_null_analysis/generate_histogram.r 
       --codelist {path}
-    needs: [generate_numeric_value_table_{test}]
+    needs: [generate_value_table_{test}]
     outputs:
       moderately_sensitive:
-        pic: output/{test}/proxy_null/numeric_values_{test}.png
-        pic2: output/{test}/proxy_null/numeric_values_zoomed_{test}.png
-  #generate_numeric_value_summary_{test}:
-  #  run: >
-  #    python:latest analysis/proxy_null_analysis/summary_stats.py
-  #  needs: [generate_numeric_value_dataset_{test}]
-  #  outputs:
-  #    moderately_sensitive:
-  #      table: output/{test}/proxy_null/numeric_value_summary_{test}.csv
+        pic: output/{test}/proxy_null/*{test}.png
 """
 
 yaml_body = ""

--- a/generate_yaml.py
+++ b/generate_yaml.py
@@ -58,7 +58,7 @@ yaml_body_template = """
     outputs:
       moderately_sensitive:
         dataset: output/{test}/proxy_null/top_1000_*_{test}.csv
-  generate_numeric_value_histogram_{test}:
+  generate_value_histogram_{test}:
     run: >
       r:latest analysis/proxy_null_analysis/generate_histogram.r 
       --codelist {path}

--- a/project.yaml
+++ b/project.yaml
@@ -23,7 +23,7 @@ actions:
     outputs:
       moderately_sensitive:
         dataset: output/alt/proxy_null/top_1000_*_alt.csv
-  generate_numeric_value_histogram_alt:
+  generate_value_histogram_alt:
     run: >
       r:latest analysis/proxy_null_analysis/generate_histogram.r 
       --codelist codelists/opensafely-alanine-aminotransferase-alt-tests.csv
@@ -112,7 +112,7 @@ actions:
     outputs:
       moderately_sensitive:
         dataset: output/chol/proxy_null/top_1000_*_chol.csv
-  generate_numeric_value_histogram_chol:
+  generate_value_histogram_chol:
     run: >
       r:latest analysis/proxy_null_analysis/generate_histogram.r 
       --codelist codelists/opensafely-cholesterol-tests.csv
@@ -201,7 +201,7 @@ actions:
     outputs:
       moderately_sensitive:
         dataset: output/hba1c/proxy_null/top_1000_*_hba1c.csv
-  generate_numeric_value_histogram_hba1c:
+  generate_value_histogram_hba1c:
     run: >
       r:latest analysis/proxy_null_analysis/generate_histogram.r 
       --codelist codelists/opensafely-glycated-haemoglobin-hba1c-tests.csv
@@ -290,7 +290,7 @@ actions:
     outputs:
       moderately_sensitive:
         dataset: output/rbc/proxy_null/top_1000_*_rbc.csv
-  generate_numeric_value_histogram_rbc:
+  generate_value_histogram_rbc:
     run: >
       r:latest analysis/proxy_null_analysis/generate_histogram.r 
       --codelist codelists/opensafely-red-blood-cell-rbc-tests.csv
@@ -379,7 +379,7 @@ actions:
     outputs:
       moderately_sensitive:
         dataset: output/sodium/proxy_null/top_1000_*_sodium.csv
-  generate_numeric_value_histogram_sodium:
+  generate_value_histogram_sodium:
     run: >
       r:latest analysis/proxy_null_analysis/generate_histogram.r 
       --codelist codelists/opensafely-sodium-tests-numerical-value.csv
@@ -468,7 +468,7 @@ actions:
     outputs:
       moderately_sensitive:
         dataset: output/hba1c_numeric/proxy_null/top_1000_*_hba1c_numeric.csv
-  generate_numeric_value_histogram_hba1c_numeric:
+  generate_value_histogram_hba1c_numeric:
     run: >
       r:latest analysis/proxy_null_analysis/generate_histogram.r 
       --codelist codelists/opensafely-glycated-haemoglobin-hba1c-tests-numerical-value.csv
@@ -557,7 +557,7 @@ actions:
     outputs:
       moderately_sensitive:
         dataset: output/vitd/proxy_null/top_1000_*_vitd.csv
-  generate_numeric_value_histogram_vitd:
+  generate_value_histogram_vitd:
     run: >
       r:latest analysis/proxy_null_analysis/generate_histogram.r 
       --codelist codelists/ardens-vitamin-d-level.csv
@@ -646,7 +646,7 @@ actions:
     outputs:
       moderately_sensitive:
         dataset: output/psa/proxy_null/top_1000_*_psa.csv
-  generate_numeric_value_histogram_psa:
+  generate_value_histogram_psa:
     run: >
       r:latest analysis/proxy_null_analysis/generate_histogram.r 
       --codelist codelists/opensafely-psa-numeric-value.csv
@@ -735,7 +735,7 @@ actions:
     outputs:
       moderately_sensitive:
         dataset: output/alt_numeric/proxy_null/top_1000_*_alt_numeric.csv
-  generate_numeric_value_histogram_alt_numeric:
+  generate_value_histogram_alt_numeric:
     run: >
       r:latest analysis/proxy_null_analysis/generate_histogram.r 
       --codelist codelists/opensafely-alanine-aminotransferase-alt-tests-numerical-value.csv

--- a/project.yaml
+++ b/project.yaml
@@ -5,40 +5,32 @@ actions:
 
 # ----------------- Test: alt ---------------------------------
 
-  generate_numeric_value_dataset_alt:
+  generate_value_dataset_alt:
     run: >
       ehrql:v1 generate-dataset
-        analysis/proxy_null_analysis/numeric_value_dataset_definition.py
-        --output output/alt/proxy_null/numeric_value_dataset_alt.csv
+        analysis/proxy_null_analysis/value_dataset_definition.py
+        --output output/alt/proxy_null/value_dataset_alt.csv
         --
         --codelist codelists/opensafely-alanine-aminotransferase-alt-tests.csv
     outputs:
       highly_sensitive:
-        dataset: output/alt/proxy_null/numeric_value_dataset_alt.csv
-  generate_numeric_value_table_alt:
+        dataset: output/alt/proxy_null/value_dataset_alt.csv
+  generate_value_table_alt:
     run: >
       r:latest analysis/proxy_null_analysis/generate_freq_table.r 
       --codelist codelists/opensafely-alanine-aminotransferase-alt-tests.csv
-    needs: [generate_numeric_value_dataset_alt]
+    needs: [generate_value_dataset_alt]
     outputs:
       moderately_sensitive:
-        dataset: output/alt/proxy_null/top_1000_numeric_values_alt.csv
+        dataset: output/alt/proxy_null/top_1000_*_alt.csv
   generate_numeric_value_histogram_alt:
     run: >
       r:latest analysis/proxy_null_analysis/generate_histogram.r 
       --codelist codelists/opensafely-alanine-aminotransferase-alt-tests.csv
-    needs: [generate_numeric_value_table_alt]
+    needs: [generate_value_table_alt]
     outputs:
       moderately_sensitive:
-        pic: output/alt/proxy_null/numeric_values_alt.png
-        pic2: output/alt/proxy_null/numeric_values_zoomed_alt.png
-  #generate_numeric_value_summary_alt:
-  #  run: >
-  #    python:latest analysis/proxy_null_analysis/summary_stats.py
-  #  needs: [generate_numeric_value_dataset_alt]
-  #  outputs:
-  #    moderately_sensitive:
-  #      table: output/alt/proxy_null/numeric_value_summary_alt.csv
+        pic: output/alt/proxy_null/*alt.png
 
   generate_measures_alt_has_test_value:
     run: >
@@ -102,40 +94,32 @@ actions:
 
 # ----------------- Test: chol ---------------------------------
 
-  generate_numeric_value_dataset_chol:
+  generate_value_dataset_chol:
     run: >
       ehrql:v1 generate-dataset
-        analysis/proxy_null_analysis/numeric_value_dataset_definition.py
-        --output output/chol/proxy_null/numeric_value_dataset_chol.csv
+        analysis/proxy_null_analysis/value_dataset_definition.py
+        --output output/chol/proxy_null/value_dataset_chol.csv
         --
         --codelist codelists/opensafely-cholesterol-tests.csv
     outputs:
       highly_sensitive:
-        dataset: output/chol/proxy_null/numeric_value_dataset_chol.csv
-  generate_numeric_value_table_chol:
+        dataset: output/chol/proxy_null/value_dataset_chol.csv
+  generate_value_table_chol:
     run: >
       r:latest analysis/proxy_null_analysis/generate_freq_table.r 
       --codelist codelists/opensafely-cholesterol-tests.csv
-    needs: [generate_numeric_value_dataset_chol]
+    needs: [generate_value_dataset_chol]
     outputs:
       moderately_sensitive:
-        dataset: output/chol/proxy_null/top_1000_numeric_values_chol.csv
+        dataset: output/chol/proxy_null/top_1000_*_chol.csv
   generate_numeric_value_histogram_chol:
     run: >
       r:latest analysis/proxy_null_analysis/generate_histogram.r 
       --codelist codelists/opensafely-cholesterol-tests.csv
-    needs: [generate_numeric_value_table_chol]
+    needs: [generate_value_table_chol]
     outputs:
       moderately_sensitive:
-        pic: output/chol/proxy_null/numeric_values_chol.png
-        pic2: output/chol/proxy_null/numeric_values_zoomed_chol.png
-  #generate_numeric_value_summary_chol:
-  #  run: >
-  #    python:latest analysis/proxy_null_analysis/summary_stats.py
-  #  needs: [generate_numeric_value_dataset_chol]
-  #  outputs:
-  #    moderately_sensitive:
-  #      table: output/chol/proxy_null/numeric_value_summary_chol.csv
+        pic: output/chol/proxy_null/*chol.png
 
   generate_measures_chol_has_test_value:
     run: >
@@ -199,40 +183,32 @@ actions:
 
 # ----------------- Test: hba1c ---------------------------------
 
-  generate_numeric_value_dataset_hba1c:
+  generate_value_dataset_hba1c:
     run: >
       ehrql:v1 generate-dataset
-        analysis/proxy_null_analysis/numeric_value_dataset_definition.py
-        --output output/hba1c/proxy_null/numeric_value_dataset_hba1c.csv
+        analysis/proxy_null_analysis/value_dataset_definition.py
+        --output output/hba1c/proxy_null/value_dataset_hba1c.csv
         --
         --codelist codelists/opensafely-glycated-haemoglobin-hba1c-tests.csv
     outputs:
       highly_sensitive:
-        dataset: output/hba1c/proxy_null/numeric_value_dataset_hba1c.csv
-  generate_numeric_value_table_hba1c:
+        dataset: output/hba1c/proxy_null/value_dataset_hba1c.csv
+  generate_value_table_hba1c:
     run: >
       r:latest analysis/proxy_null_analysis/generate_freq_table.r 
       --codelist codelists/opensafely-glycated-haemoglobin-hba1c-tests.csv
-    needs: [generate_numeric_value_dataset_hba1c]
+    needs: [generate_value_dataset_hba1c]
     outputs:
       moderately_sensitive:
-        dataset: output/hba1c/proxy_null/top_1000_numeric_values_hba1c.csv
+        dataset: output/hba1c/proxy_null/top_1000_*_hba1c.csv
   generate_numeric_value_histogram_hba1c:
     run: >
       r:latest analysis/proxy_null_analysis/generate_histogram.r 
       --codelist codelists/opensafely-glycated-haemoglobin-hba1c-tests.csv
-    needs: [generate_numeric_value_table_hba1c]
+    needs: [generate_value_table_hba1c]
     outputs:
       moderately_sensitive:
-        pic: output/hba1c/proxy_null/numeric_values_hba1c.png
-        pic2: output/hba1c/proxy_null/numeric_values_zoomed_hba1c.png
-  #generate_numeric_value_summary_hba1c:
-  #  run: >
-  #    python:latest analysis/proxy_null_analysis/summary_stats.py
-  #  needs: [generate_numeric_value_dataset_hba1c]
-  #  outputs:
-  #    moderately_sensitive:
-  #      table: output/hba1c/proxy_null/numeric_value_summary_hba1c.csv
+        pic: output/hba1c/proxy_null/*hba1c.png
 
   generate_measures_hba1c_has_test_value:
     run: >
@@ -296,40 +272,32 @@ actions:
 
 # ----------------- Test: rbc ---------------------------------
 
-  generate_numeric_value_dataset_rbc:
+  generate_value_dataset_rbc:
     run: >
       ehrql:v1 generate-dataset
-        analysis/proxy_null_analysis/numeric_value_dataset_definition.py
-        --output output/rbc/proxy_null/numeric_value_dataset_rbc.csv
+        analysis/proxy_null_analysis/value_dataset_definition.py
+        --output output/rbc/proxy_null/value_dataset_rbc.csv
         --
         --codelist codelists/opensafely-red-blood-cell-rbc-tests.csv
     outputs:
       highly_sensitive:
-        dataset: output/rbc/proxy_null/numeric_value_dataset_rbc.csv
-  generate_numeric_value_table_rbc:
+        dataset: output/rbc/proxy_null/value_dataset_rbc.csv
+  generate_value_table_rbc:
     run: >
       r:latest analysis/proxy_null_analysis/generate_freq_table.r 
       --codelist codelists/opensafely-red-blood-cell-rbc-tests.csv
-    needs: [generate_numeric_value_dataset_rbc]
+    needs: [generate_value_dataset_rbc]
     outputs:
       moderately_sensitive:
-        dataset: output/rbc/proxy_null/top_1000_numeric_values_rbc.csv
+        dataset: output/rbc/proxy_null/top_1000_*_rbc.csv
   generate_numeric_value_histogram_rbc:
     run: >
       r:latest analysis/proxy_null_analysis/generate_histogram.r 
       --codelist codelists/opensafely-red-blood-cell-rbc-tests.csv
-    needs: [generate_numeric_value_table_rbc]
+    needs: [generate_value_table_rbc]
     outputs:
       moderately_sensitive:
-        pic: output/rbc/proxy_null/numeric_values_rbc.png
-        pic2: output/rbc/proxy_null/numeric_values_zoomed_rbc.png
-  #generate_numeric_value_summary_rbc:
-  #  run: >
-  #    python:latest analysis/proxy_null_analysis/summary_stats.py
-  #  needs: [generate_numeric_value_dataset_rbc]
-  #  outputs:
-  #    moderately_sensitive:
-  #      table: output/rbc/proxy_null/numeric_value_summary_rbc.csv
+        pic: output/rbc/proxy_null/*rbc.png
 
   generate_measures_rbc_has_test_value:
     run: >
@@ -393,40 +361,32 @@ actions:
 
 # ----------------- Test: sodium ---------------------------------
 
-  generate_numeric_value_dataset_sodium:
+  generate_value_dataset_sodium:
     run: >
       ehrql:v1 generate-dataset
-        analysis/proxy_null_analysis/numeric_value_dataset_definition.py
-        --output output/sodium/proxy_null/numeric_value_dataset_sodium.csv
+        analysis/proxy_null_analysis/value_dataset_definition.py
+        --output output/sodium/proxy_null/value_dataset_sodium.csv
         --
         --codelist codelists/opensafely-sodium-tests-numerical-value.csv
     outputs:
       highly_sensitive:
-        dataset: output/sodium/proxy_null/numeric_value_dataset_sodium.csv
-  generate_numeric_value_table_sodium:
+        dataset: output/sodium/proxy_null/value_dataset_sodium.csv
+  generate_value_table_sodium:
     run: >
       r:latest analysis/proxy_null_analysis/generate_freq_table.r 
       --codelist codelists/opensafely-sodium-tests-numerical-value.csv
-    needs: [generate_numeric_value_dataset_sodium]
+    needs: [generate_value_dataset_sodium]
     outputs:
       moderately_sensitive:
-        dataset: output/sodium/proxy_null/top_1000_numeric_values_sodium.csv
+        dataset: output/sodium/proxy_null/top_1000_*_sodium.csv
   generate_numeric_value_histogram_sodium:
     run: >
       r:latest analysis/proxy_null_analysis/generate_histogram.r 
       --codelist codelists/opensafely-sodium-tests-numerical-value.csv
-    needs: [generate_numeric_value_table_sodium]
+    needs: [generate_value_table_sodium]
     outputs:
       moderately_sensitive:
-        pic: output/sodium/proxy_null/numeric_values_sodium.png
-        pic2: output/sodium/proxy_null/numeric_values_zoomed_sodium.png
-  #generate_numeric_value_summary_sodium:
-  #  run: >
-  #    python:latest analysis/proxy_null_analysis/summary_stats.py
-  #  needs: [generate_numeric_value_dataset_sodium]
-  #  outputs:
-  #    moderately_sensitive:
-  #      table: output/sodium/proxy_null/numeric_value_summary_sodium.csv
+        pic: output/sodium/proxy_null/*sodium.png
 
   generate_measures_sodium_has_test_value:
     run: >
@@ -490,40 +450,32 @@ actions:
 
 # ----------------- Test: hba1c_numeric ---------------------------------
 
-  generate_numeric_value_dataset_hba1c_numeric:
+  generate_value_dataset_hba1c_numeric:
     run: >
       ehrql:v1 generate-dataset
-        analysis/proxy_null_analysis/numeric_value_dataset_definition.py
-        --output output/hba1c_numeric/proxy_null/numeric_value_dataset_hba1c_numeric.csv
+        analysis/proxy_null_analysis/value_dataset_definition.py
+        --output output/hba1c_numeric/proxy_null/value_dataset_hba1c_numeric.csv
         --
         --codelist codelists/opensafely-glycated-haemoglobin-hba1c-tests-numerical-value.csv
     outputs:
       highly_sensitive:
-        dataset: output/hba1c_numeric/proxy_null/numeric_value_dataset_hba1c_numeric.csv
-  generate_numeric_value_table_hba1c_numeric:
+        dataset: output/hba1c_numeric/proxy_null/value_dataset_hba1c_numeric.csv
+  generate_value_table_hba1c_numeric:
     run: >
       r:latest analysis/proxy_null_analysis/generate_freq_table.r 
       --codelist codelists/opensafely-glycated-haemoglobin-hba1c-tests-numerical-value.csv
-    needs: [generate_numeric_value_dataset_hba1c_numeric]
+    needs: [generate_value_dataset_hba1c_numeric]
     outputs:
       moderately_sensitive:
-        dataset: output/hba1c_numeric/proxy_null/top_1000_numeric_values_hba1c_numeric.csv
+        dataset: output/hba1c_numeric/proxy_null/top_1000_*_hba1c_numeric.csv
   generate_numeric_value_histogram_hba1c_numeric:
     run: >
       r:latest analysis/proxy_null_analysis/generate_histogram.r 
       --codelist codelists/opensafely-glycated-haemoglobin-hba1c-tests-numerical-value.csv
-    needs: [generate_numeric_value_table_hba1c_numeric]
+    needs: [generate_value_table_hba1c_numeric]
     outputs:
       moderately_sensitive:
-        pic: output/hba1c_numeric/proxy_null/numeric_values_hba1c_numeric.png
-        pic2: output/hba1c_numeric/proxy_null/numeric_values_zoomed_hba1c_numeric.png
-  #generate_numeric_value_summary_hba1c_numeric:
-  #  run: >
-  #    python:latest analysis/proxy_null_analysis/summary_stats.py
-  #  needs: [generate_numeric_value_dataset_hba1c_numeric]
-  #  outputs:
-  #    moderately_sensitive:
-  #      table: output/hba1c_numeric/proxy_null/numeric_value_summary_hba1c_numeric.csv
+        pic: output/hba1c_numeric/proxy_null/*hba1c_numeric.png
 
   generate_measures_hba1c_numeric_has_test_value:
     run: >
@@ -587,40 +539,32 @@ actions:
 
 # ----------------- Test: vitd ---------------------------------
 
-  generate_numeric_value_dataset_vitd:
+  generate_value_dataset_vitd:
     run: >
       ehrql:v1 generate-dataset
-        analysis/proxy_null_analysis/numeric_value_dataset_definition.py
-        --output output/vitd/proxy_null/numeric_value_dataset_vitd.csv
+        analysis/proxy_null_analysis/value_dataset_definition.py
+        --output output/vitd/proxy_null/value_dataset_vitd.csv
         --
         --codelist codelists/ardens-vitamin-d-level.csv
     outputs:
       highly_sensitive:
-        dataset: output/vitd/proxy_null/numeric_value_dataset_vitd.csv
-  generate_numeric_value_table_vitd:
+        dataset: output/vitd/proxy_null/value_dataset_vitd.csv
+  generate_value_table_vitd:
     run: >
       r:latest analysis/proxy_null_analysis/generate_freq_table.r 
       --codelist codelists/ardens-vitamin-d-level.csv
-    needs: [generate_numeric_value_dataset_vitd]
+    needs: [generate_value_dataset_vitd]
     outputs:
       moderately_sensitive:
-        dataset: output/vitd/proxy_null/top_1000_numeric_values_vitd.csv
+        dataset: output/vitd/proxy_null/top_1000_*_vitd.csv
   generate_numeric_value_histogram_vitd:
     run: >
       r:latest analysis/proxy_null_analysis/generate_histogram.r 
       --codelist codelists/ardens-vitamin-d-level.csv
-    needs: [generate_numeric_value_table_vitd]
+    needs: [generate_value_table_vitd]
     outputs:
       moderately_sensitive:
-        pic: output/vitd/proxy_null/numeric_values_vitd.png
-        pic2: output/vitd/proxy_null/numeric_values_zoomed_vitd.png
-  #generate_numeric_value_summary_vitd:
-  #  run: >
-  #    python:latest analysis/proxy_null_analysis/summary_stats.py
-  #  needs: [generate_numeric_value_dataset_vitd]
-  #  outputs:
-  #    moderately_sensitive:
-  #      table: output/vitd/proxy_null/numeric_value_summary_vitd.csv
+        pic: output/vitd/proxy_null/*vitd.png
 
   generate_measures_vitd_has_test_value:
     run: >
@@ -684,40 +628,32 @@ actions:
 
 # ----------------- Test: psa ---------------------------------
 
-  generate_numeric_value_dataset_psa:
+  generate_value_dataset_psa:
     run: >
       ehrql:v1 generate-dataset
-        analysis/proxy_null_analysis/numeric_value_dataset_definition.py
-        --output output/psa/proxy_null/numeric_value_dataset_psa.csv
+        analysis/proxy_null_analysis/value_dataset_definition.py
+        --output output/psa/proxy_null/value_dataset_psa.csv
         --
         --codelist codelists/opensafely-psa-numeric-value.csv
     outputs:
       highly_sensitive:
-        dataset: output/psa/proxy_null/numeric_value_dataset_psa.csv
-  generate_numeric_value_table_psa:
+        dataset: output/psa/proxy_null/value_dataset_psa.csv
+  generate_value_table_psa:
     run: >
       r:latest analysis/proxy_null_analysis/generate_freq_table.r 
       --codelist codelists/opensafely-psa-numeric-value.csv
-    needs: [generate_numeric_value_dataset_psa]
+    needs: [generate_value_dataset_psa]
     outputs:
       moderately_sensitive:
-        dataset: output/psa/proxy_null/top_1000_numeric_values_psa.csv
+        dataset: output/psa/proxy_null/top_1000_*_psa.csv
   generate_numeric_value_histogram_psa:
     run: >
       r:latest analysis/proxy_null_analysis/generate_histogram.r 
       --codelist codelists/opensafely-psa-numeric-value.csv
-    needs: [generate_numeric_value_table_psa]
+    needs: [generate_value_table_psa]
     outputs:
       moderately_sensitive:
-        pic: output/psa/proxy_null/numeric_values_psa.png
-        pic2: output/psa/proxy_null/numeric_values_zoomed_psa.png
-  #generate_numeric_value_summary_psa:
-  #  run: >
-  #    python:latest analysis/proxy_null_analysis/summary_stats.py
-  #  needs: [generate_numeric_value_dataset_psa]
-  #  outputs:
-  #    moderately_sensitive:
-  #      table: output/psa/proxy_null/numeric_value_summary_psa.csv
+        pic: output/psa/proxy_null/*psa.png
 
   generate_measures_psa_has_test_value:
     run: >
@@ -781,40 +717,32 @@ actions:
 
 # ----------------- Test: alt_numeric ---------------------------------
 
-  generate_numeric_value_dataset_alt_numeric:
+  generate_value_dataset_alt_numeric:
     run: >
       ehrql:v1 generate-dataset
-        analysis/proxy_null_analysis/numeric_value_dataset_definition.py
-        --output output/alt_numeric/proxy_null/numeric_value_dataset_alt_numeric.csv
+        analysis/proxy_null_analysis/value_dataset_definition.py
+        --output output/alt_numeric/proxy_null/value_dataset_alt_numeric.csv
         --
         --codelist codelists/opensafely-alanine-aminotransferase-alt-tests-numerical-value.csv
     outputs:
       highly_sensitive:
-        dataset: output/alt_numeric/proxy_null/numeric_value_dataset_alt_numeric.csv
-  generate_numeric_value_table_alt_numeric:
+        dataset: output/alt_numeric/proxy_null/value_dataset_alt_numeric.csv
+  generate_value_table_alt_numeric:
     run: >
       r:latest analysis/proxy_null_analysis/generate_freq_table.r 
       --codelist codelists/opensafely-alanine-aminotransferase-alt-tests-numerical-value.csv
-    needs: [generate_numeric_value_dataset_alt_numeric]
+    needs: [generate_value_dataset_alt_numeric]
     outputs:
       moderately_sensitive:
-        dataset: output/alt_numeric/proxy_null/top_1000_numeric_values_alt_numeric.csv
+        dataset: output/alt_numeric/proxy_null/top_1000_*_alt_numeric.csv
   generate_numeric_value_histogram_alt_numeric:
     run: >
       r:latest analysis/proxy_null_analysis/generate_histogram.r 
       --codelist codelists/opensafely-alanine-aminotransferase-alt-tests-numerical-value.csv
-    needs: [generate_numeric_value_table_alt_numeric]
+    needs: [generate_value_table_alt_numeric]
     outputs:
       moderately_sensitive:
-        pic: output/alt_numeric/proxy_null/numeric_values_alt_numeric.png
-        pic2: output/alt_numeric/proxy_null/numeric_values_zoomed_alt_numeric.png
-  #generate_numeric_value_summary_alt_numeric:
-  #  run: >
-  #    python:latest analysis/proxy_null_analysis/summary_stats.py
-  #  needs: [generate_numeric_value_dataset_alt_numeric]
-  #  outputs:
-  #    moderately_sensitive:
-  #      table: output/alt_numeric/proxy_null/numeric_value_summary_alt_numeric.csv
+        pic: output/alt_numeric/proxy_null/*alt_numeric.png
 
   generate_measures_alt_numeric_has_test_value:
     run: >


### PR DESCRIPTION
### Change notes
- Add top1000 table and histogram for upper bound and lower bound
- Add table of total number of tests in time period (**note that this is a sample of 1 test per person between 2018-2024 since we used `first_for_patient()`**
- Changed histogram y-axis to display proportion rather than absolute count per value

### Actions to run
- For the following tests: alt, alt_numeric, chol, sodium, hba1c_numeric, rbc, vit_d, psa
   -  `generate_value_dataset_{test}`, `generate_value_table_{test}`, `generate_value_histogram_{test}`
