### PR TITLE
Add zero count and count of exists_for_patient()

### DIFF
--- a/analysis/proxy_null_analysis/generate_freq_table.r
+++ b/analysis/proxy_null_analysis/generate_freq_table.r
@@ -14,22 +14,30 @@ measures <- read.csv(glue('output/{test}/proxy_null/value_dataset_{test}.csv'))
 #--------- Create frequency table -------------------------------------------------
 
 fields <- c("numeric_value", "lower_bound", "upper_bound")
-total_tests_midpoint6_list <- list() 
+total_tests_mp6_list <- list() 
 
 for (field in fields) {
 
   # Select relevant columns
-  measures_sub <- select(measures, codelist_event_count, all_of(field))
+  measures_sub <- select(measures, codelist_event_count, codelist_event_exists, all_of(field))
 
   # Extract total number of tests in time period
-  total_tests <- sum(measures_sub$codelist_event_count, na.rm = TRUE)
-  total_tests_midpoint6 <- roundmid_any(total_tests)
+  total_tests_exists <- sum(measures_sub$codelist_event_exists, na.rm = TRUE)
+  total_tests_exists_mp6 <- roundmid_any(total_tests_exists)
+
+  total_tests_count <- sum(measures_sub$codelist_event_count, na.rm = TRUE)
+  total_tests_count_mp6 <- roundmid_any(total_tests_count)
+
+  total_tests_zero <- sum(measures_sub$zero_count, na.rm = TRUE)
+  total_tests_zero_mp6 <- roundmid_any(total_tests_zero)
 
   # Add total to table
-  total_tests_midpoint6_list[[length(total_tests_midpoint6_list) + 1]] <- tibble(
+  total_tests_mp6_list[[length(total_tests_mp6_list) + 1]] <- tibble(
     test = test,
     field = field,
-    total_tests_midpoint6 = total_tests_midpoint6
+    total_tests_exists_mp6 = total_tests_exists_mp6,
+    total_tests_count_mp6 = total_tests_count_mp6,
+    total_tests_zero_mp6 = total_tests_zero_mp6
   )
 
   # Generate frequency per value table
@@ -42,10 +50,10 @@ for (field in fields) {
     arrange(desc(count)) %>%
     slice_head(n = 1000) %>%
     mutate(
-      count_midpoint6 = roundmid_any(count),
-      propn_midpoint6 = ((count_midpoint6 / total_tests_midpoint6)*100)
+      count_mp6 = roundmid_any(count),
+      propn_mp6 = ((count_mp6 / total_tests_exists_mp6)*100)
     ) %>%
-    select(value, count_midpoint6, propn_midpoint6)
+    select(value, count_mp6, propn_mp6)
 
   # Save top 1000 table per field
   write.csv(
@@ -56,11 +64,11 @@ for (field in fields) {
 }
 
 # Combine all totals into one table and write it
-total_tests_midpoint6_df <- bind_rows(total_tests_midpoint6_list)
+total_tests_mp6_df <- bind_rows(total_tests_mp6_list)
 
 write_csv(
-  total_tests_midpoint6_df,
-  glue("output/{test}/proxy_null/total_tests_midpoint6_{test}.csv")
+  total_tests_mp6_df,
+  glue("output/{test}/proxy_null/total_tests_mp6_{test}.csv")
 )
 
 

--- a/analysis/proxy_null_analysis/generate_histogram.r
+++ b/analysis/proxy_null_analysis/generate_histogram.r
@@ -18,8 +18,8 @@ for (field in fields){
     # Tabulate and convert to data frame
     top_1000 <- as.data.frame(table(sim_data))
     # Rename columns for clarity
-    colnames(top_1000) <- c("value", "count_midpoint6")
-    top_1000[top_1000$value == 0, ]$count_midpoint6 <- top_1000[top_1000$value == 0, ]$count_midpoint6 + 1000
+    colnames(top_1000) <- c("value", "count_mp6")
+    top_1000[top_1000$value == 0, ]$count_mp6 <- top_1000[top_1000$value == 0, ]$count_mp6 + 1000
     # Convert 'value' from factor to numeric
     top_1000$value <- as.numeric(as.character(top_1000$value))
     # Show first few values
@@ -30,14 +30,13 @@ for (field in fields){
 
   # Round floats to nearest integer (i.e. binning)
   top_1000$value <- round(top_1000$value)
-
   # Aggregate to get propn per integer
   aggregated_top_1000 <- top_1000 %>%
     group_by(value) %>%
-    summarise(total_propn_midpoint6 = sum(propn_midpoint6), .groups = "drop")
+    summarise(total_propn_mp6 = sum(propn_mp6), .groups = "drop")
 
   # Generate histogram
-  p <- ggplot(aggregated_top_1000, aes(x = value, y = total_propn_midpoint6)) +
+  p <- ggplot(aggregated_top_1000, aes(x = value, y = total_propn_mp6)) +
     geom_bar(stat = "identity", 
             fill = "lightblue", 
             color = "black", 

--- a/analysis/proxy_null_analysis/test_value_dataset_definition.py
+++ b/analysis/proxy_null_analysis/test_value_dataset_definition.py
@@ -1,0 +1,39 @@
+from datetime import date
+
+from analysis.proxy_null_analysis.value_dataset_definition import dataset  
+
+test_data = { #tests alt
+    1: {
+        "clinical_events_ranges": [
+            {
+                "numeric_value": 34,
+                "snomedct_code": "1013211000000103",
+                "date": date(2020, 4, 1),
+                "lower_bound": 0,
+                "upper_bound": 76,
+                "comparator": "<",
+            },
+            {
+                "numeric_value": 0,
+                "snomedct_code": "1013211000000103",
+                "date": date(2020, 5, 1),
+                "lower_bound": 2,
+                "upper_bound": 100,
+                "comparator": "~",
+            },
+        ],
+        "patients": {
+
+        },
+        "expected_in_population": True,
+        "expected_columns": {
+            "zero_count": 1,
+            "codelist_event_count": 2,
+            "codelist_event_exists": 1,
+            "numeric_value": 34,
+            "upper_bound": 76,
+            "lower_bound": 0
+        },
+    }
+}
+

--- a/analysis/proxy_null_analysis/value_dataset_definition.py
+++ b/analysis/proxy_null_analysis/value_dataset_definition.py
@@ -2,7 +2,7 @@
 # Args: --codelist [codelist]
 
 import argparse
-from ehrql import codelist_from_csv
+from ehrql import codelist_from_csv, years
 from ehrql.tables.core import patients
 from ehrql.tables.tpp import (
     practice_registrations as registrations,
@@ -15,7 +15,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--codelist")
 args = parser.parse_args()
 start_date = "2018-01-01"
-end_date = "2024-01-01"
+end_date = start_date + years(7)
 
 # Codelists
 # --------------------------------------------------------------------------------------
@@ -29,7 +29,10 @@ codelist_events = clinical_events_ranges.where(
 )
 
 # Extract numeric values for codelist
-dataset.codelist_event_count = codelist_events.exists_for_patient()
+dataset.codelist_event_count = codelist_events.count_for_patient()
+dataset.zero_count = codelist_events.sort_by(codelist_events.date).where(codelist_events.numeric_value == 0).count_for_patient()
+
+dataset.codelist_event_exists = codelist_events.exists_for_patient()
 dataset.numeric_value = codelist_events.sort_by(codelist_events.date).first_for_patient().numeric_value
 dataset.upper_bound = codelist_events.sort_by(codelist_events.date).first_for_patient().upper_bound
 dataset.lower_bound = codelist_events.sort_by(codelist_events.date).first_for_patient().lower_bound

--- a/generate_yaml.py
+++ b/generate_yaml.py
@@ -58,7 +58,7 @@ yaml_body_template = """
     outputs:
       moderately_sensitive:
         dataset: output/{test}/proxy_null/top_1000_*_{test}.csv
-        totals: output/{test}/proxy_null/total_tests_midpoint6_{test}.csv
+        totals: output/{test}/proxy_null/total_tests_mp6_{test}.csv
   generate_value_histogram_{test}:
     run: >
       r:latest analysis/proxy_null_analysis/generate_histogram.r 
@@ -114,6 +114,17 @@ yaml_summary = '''
     outputs:
       highly_sensitive:
         dataset: output/test_dataset.csv
+  generate_test_value_dataset:
+    run: >
+        ehrql:v1 generate-dataset
+          analysis/proxy_null_analysis/value_dataset_definition.py
+          --output output/test_value_dataset.csv
+          --test-data-file analysis/proxy_null_analysis/test_value_dataset_definition.py
+          --
+          --codelist codelists/opensafely-alanine-aminotransferase-alt-tests.csv
+    outputs:
+      highly_sensitive:
+        dataset: output/test_value_dataset.csv
 '''
 yaml = yaml_header + yaml_body + yaml_summary
 with open("project.yaml", "w") as file:

--- a/project.yaml
+++ b/project.yaml
@@ -23,7 +23,7 @@ actions:
     outputs:
       moderately_sensitive:
         dataset: output/alt/proxy_null/top_1000_*_alt.csv
-        totals: output/alt/proxy_null/total_tests_midpoint6_alt.csv
+        totals: output/alt/proxy_null/total_tests_mp6_alt.csv
   generate_value_histogram_alt:
     run: >
       r:latest analysis/proxy_null_analysis/generate_histogram.r 
@@ -113,7 +113,7 @@ actions:
     outputs:
       moderately_sensitive:
         dataset: output/chol/proxy_null/top_1000_*_chol.csv
-        totals: output/chol/proxy_null/total_tests_midpoint6_chol.csv
+        totals: output/chol/proxy_null/total_tests_mp6_chol.csv
   generate_value_histogram_chol:
     run: >
       r:latest analysis/proxy_null_analysis/generate_histogram.r 
@@ -203,7 +203,7 @@ actions:
     outputs:
       moderately_sensitive:
         dataset: output/hba1c/proxy_null/top_1000_*_hba1c.csv
-        totals: output/hba1c/proxy_null/total_tests_midpoint6_hba1c.csv
+        totals: output/hba1c/proxy_null/total_tests_mp6_hba1c.csv
   generate_value_histogram_hba1c:
     run: >
       r:latest analysis/proxy_null_analysis/generate_histogram.r 
@@ -293,7 +293,7 @@ actions:
     outputs:
       moderately_sensitive:
         dataset: output/rbc/proxy_null/top_1000_*_rbc.csv
-        totals: output/rbc/proxy_null/total_tests_midpoint6_rbc.csv
+        totals: output/rbc/proxy_null/total_tests_mp6_rbc.csv
   generate_value_histogram_rbc:
     run: >
       r:latest analysis/proxy_null_analysis/generate_histogram.r 
@@ -383,7 +383,7 @@ actions:
     outputs:
       moderately_sensitive:
         dataset: output/sodium/proxy_null/top_1000_*_sodium.csv
-        totals: output/sodium/proxy_null/total_tests_midpoint6_sodium.csv
+        totals: output/sodium/proxy_null/total_tests_mp6_sodium.csv
   generate_value_histogram_sodium:
     run: >
       r:latest analysis/proxy_null_analysis/generate_histogram.r 
@@ -473,7 +473,7 @@ actions:
     outputs:
       moderately_sensitive:
         dataset: output/hba1c_numeric/proxy_null/top_1000_*_hba1c_numeric.csv
-        totals: output/hba1c_numeric/proxy_null/total_tests_midpoint6_hba1c_numeric.csv
+        totals: output/hba1c_numeric/proxy_null/total_tests_mp6_hba1c_numeric.csv
   generate_value_histogram_hba1c_numeric:
     run: >
       r:latest analysis/proxy_null_analysis/generate_histogram.r 
@@ -563,7 +563,7 @@ actions:
     outputs:
       moderately_sensitive:
         dataset: output/vitd/proxy_null/top_1000_*_vitd.csv
-        totals: output/vitd/proxy_null/total_tests_midpoint6_vitd.csv
+        totals: output/vitd/proxy_null/total_tests_mp6_vitd.csv
   generate_value_histogram_vitd:
     run: >
       r:latest analysis/proxy_null_analysis/generate_histogram.r 
@@ -653,7 +653,7 @@ actions:
     outputs:
       moderately_sensitive:
         dataset: output/psa/proxy_null/top_1000_*_psa.csv
-        totals: output/psa/proxy_null/total_tests_midpoint6_psa.csv
+        totals: output/psa/proxy_null/total_tests_mp6_psa.csv
   generate_value_histogram_psa:
     run: >
       r:latest analysis/proxy_null_analysis/generate_histogram.r 
@@ -743,7 +743,7 @@ actions:
     outputs:
       moderately_sensitive:
         dataset: output/alt_numeric/proxy_null/top_1000_*_alt_numeric.csv
-        totals: output/alt_numeric/proxy_null/total_tests_midpoint6_alt_numeric.csv
+        totals: output/alt_numeric/proxy_null/total_tests_mp6_alt_numeric.csv
   generate_value_histogram_alt_numeric:
     run: >
       r:latest analysis/proxy_null_analysis/generate_histogram.r 
@@ -835,3 +835,14 @@ actions:
     outputs:
       highly_sensitive:
         dataset: output/test_dataset.csv
+  generate_test_value_dataset:
+    run: >
+        ehrql:v1 generate-dataset
+          analysis/proxy_null_analysis/value_dataset_definition.py
+          --output output/test_value_dataset.csv
+          --test-data-file analysis/proxy_null_analysis/test_value_dataset_definition.py
+          --
+          --codelist codelists/opensafely-alanine-aminotransferase-alt-tests.csv
+    outputs:
+      highly_sensitive:
+        dataset: output/test_value_dataset.csv


### PR DESCRIPTION
- Added a count of the total number of zeroes
- Changed codelist event count to two counts (1) total `exists_for_patient()` (2) total `count_for_patient()`
   - (1) is used for calculating the frequency of numeric values, since we can only extract one per patient using `first_for_patient()`. Not ideal, but a limitation of not having event-level data.
   - (2) is used to calculate the frequency of zeroes, since we can count all events per patient when looking at a single numeric value.
- Changed end date from Jan 1 2024 to Jan 1 2025 so that it aligns with measures extracts